### PR TITLE
Feature/open links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "mdoc" extension are documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.2.0] - 2020-09-30
+### Added
+- Path for currently opened document is displayed at the top of documentation window. This can copied.
+  - When such an URL is opened, the extension will handle it, and opens the document pointed at. Repositories are identified by their remote's (origin) url.
+
 ## [1.1.1] - 2020-08-06
 ### Added
 - Current search will appear in the project tree, to aid navigation between search and results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 - Path for currently opened document is displayed at the top of documentation window. This can copied.
   - When such an URL is opened, the extension will handle it, and opens the document pointed at. Repositories are identified by their remote's (origin) url.
+- `mdoc.open` command (by default is bound to `Ctrl+F1`). This displays a quick pick, where you can search among all the documents. You can insert URL copied from the document headers too (for ex. when you receive an mdoc link from someone)
 
 ## [1.1.1] - 2020-08-06
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "mdoc",
 	"displayName": "mdoc - Markdown Documentation Viewer",
 	"description": "markdown documentation viewer for Visual Studio Code",
-	"version": "1.1.1",
+	"version": "1.2.0-beta.1",
 	"publisher": "bxantus",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "mdoc",
 	"displayName": "mdoc - Markdown Documentation Viewer",
 	"description": "markdown documentation viewer for Visual Studio Code",
-	"version": "1.2.0-beta.1",
+	"version": "1.2.0-beta.2",
 	"publisher": "bxantus",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
 				"category": "mdoc"
 			},
 			{
+				"command": "mdoc.open",
+				"title": "Open document",
+				"category": "mdoc"
+			},
+			{
 				"command": "mdoc.project.update",
 				"title": "Update project",
 				"icon": "$(sync)"
@@ -125,6 +130,12 @@
 			{
 				"view": "mdocProjects",
 				"contents": "No documentation projects added.\n[Add project from filesystem](command:mdoc.add.fromFilesystem)"
+			}
+		],
+		"keybindings": [
+			{
+				"key": "Ctrl+F1",
+				"command": "mdoc.open"
 			}
 		]
 	},

--- a/src/gui/docViewer.ts
+++ b/src/gui/docViewer.ts
@@ -277,7 +277,9 @@ class DocViewer implements vscode.Disposable {
             </head>
             <body>
                 <div id="__header">
-                    ${this.generateDocUrlHtml(document)}
+                    <div>
+                        ${this.generateDocUrlHtml(document, title)}
+                    </div>
                 </div>
                 <div id="__markdown-content">
                     ${markdownContent}
@@ -321,20 +323,26 @@ class DocViewer implements vscode.Disposable {
         return html
     }
 
-    private generateDocUrlHtml(document:Document) {
+    private generateDocUrlHtml(document:Document, title:string) {
         // get path for currently opened document
         let docPathHtml = ""
-        if (document.source) { // doc inside projects
-            let documentNode = this.projectProvider?.getNodeForUri(document.source, document.projectUrl )
+        const source = document.source ?? this.#current?.source;
+        if (source) { // doc inside projects, or external link, but we have a source at hand
+            let documentNode = this.projectProvider?.getNodeForUri(source, document.projectUrl )
             for (; documentNode; documentNode = documentNode.parent) // todo: maybe html parts should be encoded 
                 docPathHtml = `<a class="doc-url" >${documentNode.label}</a>`  
-                              + (docPathHtml.length > 0 ? `<span class="url-separator>">/</span>` : "") 
+                              + (docPathHtml.length > 0 ? `<span class="url-separator">/</span>` : "") 
                               + docPathHtml;
             
-            docPathHtml += `<button id="copy-url" class="copy">Copy Url</button>` // todo: this should be designed!
-        } else {
-            // document is coming from an external url, decide how to display url
+            if (document.source)
+                docPathHtml += `<button id="copy-url" class="copy button">copy url</button>` 
+            else {
+                // document is coming from an external url, decide how to implement copy
+            }
+        } else { // at least show title
+            docPathHtml = `<a class="doc-url" >${title}</a>`  
         }
+        
         return docPathHtml
     }
 

--- a/src/gui/docViewer.ts
+++ b/src/gui/docViewer.ts
@@ -100,6 +100,32 @@ class DocViewer implements vscode.Disposable {
                 dropSource(node.project.source)
             }
         }))
+
+        context.subscriptions.push(vscode.window.registerUriHandler(this))
+    }
+
+    async handleUri(uri:vscode.Uri) {
+        console.log("mdoc received an uri: ", uri.toString())
+        const pathCommand = uri.path.substr(1)
+        const commandEnd = pathCommand.indexOf("/")
+        const command = pathCommand.substr(0, commandEnd)
+        const arg = pathCommand.substr(commandEnd + 1)
+        if (command == "open") {
+            const urlEnd = arg.indexOf(".git/") + 4
+            const remoteUrl = arg.substr(0, arg.indexOf(".git/") + 4) // include the git repo's name
+            const docUrl = arg.substr(urlEnd + 1)
+            let success = false
+            for (const project of this.projects) {
+                const projUrl = (await project.source.getRemoteUrl()).replace("://", "/") // the same change is performed, as when original url is created
+                if (projUrl == remoteUrl) {
+                    const documentNode = this.projectProvider?.getNodeForUri(project.source, docUrl )
+                    success = await this.openDocument(project.source, docUrl, documentNode?.label ?? "")
+                    break
+                }
+            }
+            if (!success)
+                vscode.window.showErrorMessage(`Can't open document '${docUrl}' in '${remoteUrl}'`)
+        }
     }
 
     #documentWatch:vscode.Disposable|undefined
@@ -125,8 +151,9 @@ class DocViewer implements vscode.Disposable {
                         proj.docSearch.invalidateIndex()
                 })
             }
+            return true
         }
-        
+        return false
     }
 
     async addProject(projSource:SourceAdapter) {
@@ -227,6 +254,7 @@ class DocViewer implements vscode.Disposable {
         md.use(markdownItAnchor, {level: [1, 2, 3], slugify: (s:string) => slugify(s, slugs)})
         const markdownContent = md.render(document.markdownContent.toString())
 
+        
         const htmlContent = 
             `
             <head>
@@ -236,6 +264,9 @@ class DocViewer implements vscode.Disposable {
                 <script src="${viewerJs}"></script>
             </head>
             <body>
+                <div id="__header">
+                    ${this.generateDocUrlHtml(document)}
+                </div>
                 <div id="__markdown-content">
                     ${markdownContent}
                 </div>
@@ -276,6 +307,23 @@ class DocViewer implements vscode.Disposable {
         html += "</ul>\n" // close outer heading
         
         return html
+    }
+
+    private generateDocUrlHtml(document:Document) {
+        // get path for currently opened document
+        let docPathHtml = ""
+        if (document.source) { // doc inside projects
+            let documentNode = this.projectProvider?.getNodeForUri(document.source, document.projectUrl )
+            for (; documentNode; documentNode = documentNode.parent) // todo: maybe html parts should be encoded 
+                docPathHtml = `<a class="doc-url" >${documentNode.label}</a>`  
+                              + (docPathHtml.length > 0 ? `<span class="url-separator>">/</span>` : "") 
+                              + docPathHtml;
+            
+            docPathHtml += `<button id="copy-url" class="copy">Copy Url</button>` // todo: this should be designed!
+        } else {
+            // document is coming from an external url, decide how to display url
+        }
+        return docPathHtml
     }
 
     private async loadSearchInViewer(proj:Project) {
@@ -358,7 +406,8 @@ class DocViewer implements vscode.Disposable {
                 this.#current.dirty = false
             }
         })
-        panel.webview.onDidReceiveMessage(message=> {
+        panel.webview.onDidReceiveMessage(async message=> {
+            // todo: should register message handlers in a dictionary (object) and call that here instead of if else
             if (message.command == "openLink" && this.#current) {
                 const base = /^[a-z][a-z\d.+-]+:/i.test(this.#current.uri) ? this.#current.uri : `mdoc:///${this.#current.uri}` // if current has no scheme, we add one, otherwise URL parse fails
                 const docUrl = new URL(message.href, base)
@@ -376,6 +425,10 @@ class DocViewer implements vscode.Disposable {
                     project.searchState.query = message.query
                     this.scheduleSearch(project, message.query)
                 }
+            } else if (message.command == "copyUrl" && this.#current) {
+                const remoteUrl = (await this.#current.source.getRemoteUrl()).replace("://", "/")
+
+                vscode.env.clipboard.writeText(`vscode://bxantus.mdoc/open/${remoteUrl}/${this.#current.uri}`); 
             }
         })
         return panel

--- a/src/gui/docViewer.ts
+++ b/src/gui/docViewer.ts
@@ -11,7 +11,7 @@ import { DocSearch, SearchResult } from '../search/docSearch';
 import { getSearchHelpInHtml } from "./search"
 import { sanitizeCodeFence } from '../util/sanitizeHtml';
 import { dropSource } from '../extension';
-import { showDocumentPicker } from './openPicker';
+import { DocumentItem, showDocumentPicker } from './openPicker';
 
 interface SearchState {
     query:string
@@ -106,8 +106,10 @@ class DocViewer implements vscode.Disposable {
 
         context.subscriptions.push(vscode.commands.registerCommand("mdoc.open", async ()=> {
             const doc = await showDocumentPicker(this.projects);
-            if (doc)
-                this.openDocument(doc.source, doc.docUri, doc.label)
+            if (doc) {
+                if (doc instanceof DocumentItem ) this.openDocument(doc.source, doc.docUri, doc.label)
+                else this.handleUri(doc.uri)
+            }
         }))
     }
 

--- a/src/gui/openPicker.ts
+++ b/src/gui/openPicker.ts
@@ -1,0 +1,60 @@
+import { QuickPick, QuickPickItem, window } from 'vscode'
+import { allTreeItems, ProjectTree, SourceAdapter, TreeItemVal } from '../source/sourceAdapter'
+
+interface Project {
+    source: SourceAdapter
+    projectTree:  ProjectTree
+}
+
+export async function showDocumentPicker(projects:Project[]) {
+    const quickPick = new DocumentPicker(window.createQuickPick(), projects)
+    return quickPick.show()
+}
+
+class DocumentItem implements QuickPickItem {
+    get docUri():string { return this.treeItem.docUri as string }
+
+    get label():string { return this.treeItem.label }
+    get detail():string { return this._source.title }
+    get source() { return  this._source }
+
+    description:string
+    constructor(private _source:SourceAdapter, private treeItem:TreeItemVal) {
+        // compute path to root in description, like: uie docs/reference/sys modules. 
+        let path:string[] = []
+        for (let p = treeItem.parent; p && p.parent; p = p.parent) { // won't add root element to the path
+            path.unshift(p.label)
+        }
+        this.description = path.join('/')   
+    }
+}
+
+class DocumentPicker  {
+    constructor(private quickPick:QuickPick<DocumentItem>, private projects:Project[]) {
+        quickPick.placeholder = "Open document"
+        for (const proj of projects)
+            this.fillItemsFrom(proj)
+    }
+
+    show():Promise<DocumentItem|undefined> {
+        return new Promise<DocumentItem|undefined>((resolve, reject) => {
+            this.quickPick.show()
+            let hideListener = this.quickPick.onDidHide( e => resolve(undefined))
+            this.quickPick.onDidAccept( e => {
+                hideListener.dispose()
+                this.quickPick.hide()
+                const selected = this.quickPick.selectedItems[0]
+                resolve(selected)
+            })
+        })
+    }
+
+    private fillItemsFrom(proj:Project) {
+        let items:DocumentItem[] = []
+        for (const treeItem of allTreeItems(proj.projectTree, proj.source)) {
+            if (treeItem.docUri)
+                items.push(new DocumentItem(proj.source, treeItem))
+        }
+        this.quickPick.items = this.quickPick.items.concat(items)
+    }
+}

--- a/src/gui/openPicker.ts
+++ b/src/gui/openPicker.ts
@@ -30,7 +30,7 @@ export class DocumentItem implements QuickPickItem {
 }
 
 export class DocumentUriItem implements QuickPickItem {
-    get detail():string { return "mdoc URI" }
+    get detail():string { return "document URL" }
 
     get uri() { return Uri.parse(this.label) }
 

--- a/src/source/sourceAdapter.ts
+++ b/src/source/sourceAdapter.ts
@@ -23,6 +23,8 @@ export interface SourceAdapter extends Disposable {
 
 
     update():Promise<UpdateResult>
+    getRemoteUrl():Promise<string>  // URL of the remote git repository for this source. for sources added from git repos, this is the same as uri. 
+                                    // For sources from fs, this is the origin remote's url
 
     onProjectTreeChanged:Event<ProjectTree>
     onTitleChanged:Event<string>

--- a/src/source/sourceAdapter.ts
+++ b/src/source/sourceAdapter.ts
@@ -56,3 +56,24 @@ export async function getDocument(source:SourceAdapter, docUri:string):Promise<D
         }
     } else return source.getDocument(docUri)
 }
+
+/// This interface will be used when iterationg over the project tree
+export interface TreeItemVal {
+    label:string
+    docUri?:string
+    parent?:TreeItemVal
+}
+
+export function* allTreeItems(tree:ProjectTree, source:SourceAdapter) : Generator<TreeItemVal> {
+    const root = { label: source.title, docUri:'README.md' }
+    yield root
+    for (const child of tree.children) 
+        yield * allTreeChildren(child, root);
+}
+
+function *allTreeChildren(tree:TreeNode, parent:TreeItemVal) {
+    const itemVal = {label: tree.label, docUri: tree.docUri, parent}
+    yield itemVal
+    for (const child of tree.children) 
+        yield * allTreeChildren(child, itemVal);
+}

--- a/www/viewer.css
+++ b/www/viewer.css
@@ -1,5 +1,77 @@
 :root {
     --side-width: 175px;
+    --header-top-margin: 15px;
+    --header-box-size: 35px;
+    --header-height: calc(var(--header-box-size) + 2 * var(--header-top-margin)); 
+    --markdown-margin: 26px; /* see markdown.css, value taken from there */
+    --body-padding: 20px;
+}
+
+h1, h2, h3, h4, img, a {
+    scroll-margin-top: var(--header-height);
+}
+
+#__header {
+    position: fixed;
+    left:0px;
+    top: 0px;
+    right: calc(var(--side-width) + var(--markdown-margin));
+    height: var(--header-height);
+    box-sizing: content-box;
+    
+    background-color: var(--vscode-editor-background);
+    z-index: 1;
+    
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+    padding-left: calc(2 * var(--markdown-margin) + var(--body-padding));  /*adding body padding + html margin*/
+    padding-right: calc(var(--markdown-margin) + var(--body-padding));
+}
+
+#__header > div {
+    display: flex;
+    align-items: center;
+    height: var(--header-box-size);
+    border: solid 1px var(--vscode-textSeparator-foreground); 
+
+    white-space: nowrap;
+    overflow: hidden;
+
+    padding-left: 14px;
+    padding-bottom: 2px;
+}
+
+#__header .url-separator {
+    margin: 0 10px;
+    color: var(--vscode-textSeparator-foreground); /*var(--vscode-activityBar-inactiveForeground);/*var(--vscode-tab-inactiveBackground);*/
+    opacity: 70%;
+}
+
+#__header a {
+    cursor: pointer;
+}
+
+#__header button {
+    background-color: var(--vscode-badge-background);
+    color: var(--vscode-editor-foreground);
+    font-size: 12px;
+    border-style: none;
+    border-radius: 20px;
+    cursor: pointer;
+    padding-left: 8px;
+    padding-right: 9px;
+    padding-top: 3px;
+    padding-bottom: 3px;
+}
+
+#__header button.copy {
+    margin-left: 25px;
+}
+
+#__header button:focus {
+    outline: none;
 }
 
 #__side, #__side-search {
@@ -9,7 +81,7 @@
     right: 0px;
     top: 0px;
     margin-right: 26px;
-    margin-top: 26px;
+    margin-top: var(--header-top-margin);
     height: calc(100vh - 26px);
     overflow-y: scroll;
     overflow-x: hidden;
@@ -17,6 +89,7 @@
 
 #__side-search {
     line-height: 1.2em;
+    margin-top: 26px;
 }
 
 #__side a {
@@ -45,6 +118,7 @@
 }
 
 #__markdown-content {
+    margin-top: var(--header-height);
     margin-right: var(--side-width);
 }
 

--- a/www/viewer.js
+++ b/www/viewer.js
@@ -39,3 +39,12 @@ window.addEventListener('message', event => {
     if (action)
         action(message)
 })
+
+window.addEventListener('load', () => {
+    const urlCopy = document.getElementById("copy-url")
+    urlCopy.onclick = e => {
+        vscode.postMessage({
+            command: "copyUrl"
+        })
+    }
+})


### PR DESCRIPTION
Path for currently opened document is displayed at the top of documentation window. This can copied.
  - When such an URL is opened, the extension will handle it, and opens the document pointed at. Repositories are identified by their remote's (origin) url.
- `mdoc.open` command (by default is bound to `Ctrl+F1`). This displays a quick pick, where you can search among all the documents. You can insert URL copied from the document headers too (for ex. when you receive an mdoc link from someone)

